### PR TITLE
Force keeping independent state of coordinates and custom mine setup

### DIFF
--- a/api/src/test/scala/io/scalac/minesweeper/api/BoardFactorySpec.scala
+++ b/api/src/test/scala/io/scalac/minesweeper/api/BoardFactorySpec.scala
@@ -14,3 +14,8 @@ abstract class BoardFactorySpec(create: () => BoardFactory) extends FunSuite:
       assertEquals(c.hashCode() % 2 == 0, board.hasMine(c))
     )
   }
+
+  test("Should set all mines") {
+    val board = create().create(5, _ => true)
+    board.allCoordinates.foreach(c => assert(board.hasMine(c)))
+  }

--- a/api/src/test/scala/io/scalac/minesweeper/api/BoardSpec.scala
+++ b/api/src/test/scala/io/scalac/minesweeper/api/BoardSpec.scala
@@ -19,12 +19,34 @@ abstract class BoardSpec(factory: BoardFactory) extends FunSuite:
       .foreach(assertEquals(_, Coordinate.State.Flagged))
   }
 
+  test("Flagging one coordinate should not affect other coordinates") {
+    val board = createBoard()
+
+    board.allCoordinates
+      .map(coordinate => (coordinate, board.flag(coordinate)))
+      .foreach { case (coordinate, updatedBoard) =>
+        updatedBoard.allCoordinates
+          .filterNot(_ == coordinate)
+          .foreach { c =>
+            assertEquals(updatedBoard.stateAt(c), board.stateAt(c))
+          }
+      }
+  }
+
   test("Uncovering any empty coordinate should set coordinate as uncovered") {
     val board = createBoard()
 
     coordinatesWithoutMine(board)
       .map(coordinate => board.uncover(coordinate).stateAt(coordinate))
       .foreach(assertEquals(_, Coordinate.State.Uncovered))
+  }
+
+  test("Uncovering some empty coordinate should keep state as Playing") {
+    val board = createBoard()
+
+    coordinatesWithoutMine(board)
+      .map(coordinate => board.uncover(coordinate).state)
+      .foreach(assertEquals(_, Board.State.Playing))
   }
 
   test("Board state should start as Playing") {

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
@@ -2,9 +2,9 @@ package io.scalac.minesweeper.squared
 
 import io.scalac.minesweeper.api.*
 
-class SquaredBoard extends Board:
+class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board:
   override def uncover(coordinate: Coordinate): Board =
-    new SquaredBoard:
+    new SquaredBoard(size, _hasMine):
       override def stateAt(_coordinate: Coordinate): Coordinate.State =
         if SquaredBoard.this.stateAt(_coordinate) == Coordinate.State.Flagged
         then Coordinate.State.Flagged
@@ -15,18 +15,25 @@ class SquaredBoard extends Board:
           if stateAt(coordinate) == Coordinate.State.Flagged
           then SquaredBoard.this.state
           else Board.State.Lost
-        else Board.State.Won
+        else if (won()) Board.State.Won
+        else Board.State.Playing
+
+  private def won(): Boolean =
+    allCoordinates
+      .filter(!hasMine(_))
+      .forall(stateAt(_) == Coordinate.State.Uncovered)
 
   override def flag(coordinate: Coordinate): Board =
-    new SquaredBoard:
+    new SquaredBoard(size, _hasMine):
       override def stateAt(_coordinate: Coordinate): Coordinate.State =
-        Coordinate.State.Flagged
+        if (_coordinate == coordinate) Coordinate.State.Flagged
+        else SquaredBoard.this.stateAt(_coordinate)
 
   override def allCoordinates: Seq[Coordinate] =
-    Seq.tabulate(5)(SquaredCoordinate(_, 0))
+    Seq.tabulate(size)(SquaredCoordinate(_, 0))
 
   override def hasMine(coordinate: Coordinate): Boolean =
-    coordinate.hashCode() % 2 == 0
+    _hasMine(coordinate)
 
   override def stateAt(coordinate: Coordinate): Coordinate.State =
     Coordinate.State.Covered

--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoardFactory.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoardFactory.scala
@@ -4,4 +4,4 @@ import io.scalac.minesweeper.api.{BoardFactory, Coordinate}
 
 class SquaredBoardFactory extends BoardFactory:
   override def create(size: Int, hasMine: Coordinate => Boolean): SquaredBoard =
-    SquaredBoard()
+    SquaredBoard(size, hasMine)


### PR DESCRIPTION
With these new tests the implementation finally makes more sense.
It keeps the state of each independent coordinate, and the setting of which one has mine is not just stolen from the spec.
Why does it still not look truly as a "squared" implementation of the game?