### PR TITLE
Test squared implementation specifically

### DIFF
--- a/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
+++ b/squared/src/main/scala/io/scalac/minesweeper/squared/SquaredBoard.scala
@@ -3,19 +3,22 @@ package io.scalac.minesweeper.squared
 import io.scalac.minesweeper.api.*
 
 class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board:
+  previous =>
+
   override def uncover(coordinate: Coordinate): Board =
     new SquaredBoard(size, _hasMine):
       override def stateAt(_coordinate: Coordinate): Coordinate.State =
-        if SquaredBoard.this.stateAt(_coordinate) == Coordinate.State.Flagged
+        if previous.stateAt(_coordinate) == Coordinate.State.Flagged
         then Coordinate.State.Flagged
         else Coordinate.State.Uncovered
 
       override def state: Board.State =
         if hasMine(coordinate) then
           if stateAt(coordinate) == Coordinate.State.Flagged
-          then SquaredBoard.this.state
+          then previous.state
           else Board.State.Lost
-        else if (won()) Board.State.Won
+        else if won()
+        then Board.State.Won
         else Board.State.Playing
 
   private def won(): Boolean =
@@ -26,11 +29,13 @@ class SquaredBoard(size: Int, _hasMine: Coordinate => Boolean) extends Board:
   override def flag(coordinate: Coordinate): Board =
     new SquaredBoard(size, _hasMine):
       override def stateAt(_coordinate: Coordinate): Coordinate.State =
-        if (_coordinate == coordinate) Coordinate.State.Flagged
-        else SquaredBoard.this.stateAt(_coordinate)
+        if _coordinate == coordinate
+        then Coordinate.State.Flagged
+        else previous.stateAt(_coordinate)
 
-  override def allCoordinates: Seq[Coordinate] =
-    Seq.tabulate(size)(SquaredCoordinate(_, 0))
+  override lazy val allCoordinates: Seq[SquaredCoordinate] =
+    val sqrt = math.sqrt(size.toDouble).round.toInt
+    (0 until size).map(n => SquaredCoordinate(n / sqrt, n % sqrt))
 
   override def hasMine(coordinate: Coordinate): Boolean =
     _hasMine(coordinate)

--- a/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredBoardSpec.scala
+++ b/squared/src/test/scala/io/scalac/minesweeper/squared/SquaredBoardSpec.scala
@@ -2,4 +2,14 @@ package io.scalac.minesweeper.squared
 
 import io.scalac.minesweeper.api.BoardSpec
 
-class SquaredBoardSpec extends BoardSpec(SquaredBoardFactory())
+class SquaredBoardSpec extends BoardSpec(SquaredBoardFactory()):
+  test("Should contain all coordinates") {
+    val board = new SquaredBoard(9, _ => false)
+    val coordinates = for {
+      x <- 0 until 3
+      y <- 0 until 3
+    } yield SquaredCoordinate(x, y)
+
+    board.allCoordinates.foreach(c => assert(coordinates.contains(c)))
+    coordinates.foreach(c => assert(board.allCoordinates.contains(c)))
+  }


### PR DESCRIPTION
The squared implementation doesn't have any actual requirement to be squared.
The abstract api tests can't check that because in fact they don't care about implementation details.
Tests have to be added in the squared module itself and by knowing the implementation details, more specific tests can be added, and the implementation now is forced to show more squared-like properties.